### PR TITLE
Gradle update

### DIFF
--- a/cadc-wcs/README.md
+++ b/cadc-wcs/README.md
@@ -1,21 +1,22 @@
-CADC WCS 2.0
+CADC WCS 3.0
 ============
 
-The cadc-wcs library is the java interface to `wcslib` (http://www.atnf.csiro.au/people/mcalabre/WCS/). 
+The cadc-wcs library is the java interface to `wcslib` (http://www.atnf.csiro.au/people/mcalabre/WCS/).
 
-This library can be built on its own but testing and beyond requires wcslib. The JNI binding library is
+This library can be built on its own but testing and beyond requires `wcslib`. The JNI binding library is
 compiled and included inside the `cadc-wcs` JAR file and deployed during class loading.
 
 Versions: 
-- cadc-wcs-1.x binaries on JCenter are linked against wcslib-4
-- cadc-wcs-2.x binaries on JCenter are linked against >= wcslib-5
+- cadc-wcs 1.x binaries on JCenter are linked against wcslib 4
+- cadc-wcs 2.x binaries on JCenter are linked against wcslib >= 5
+- cadc-wcs 3.x binaries on JCenter are linked against wcslib >= 7.4
 
 Building & Testing
 ------------------
 
-Gradle is used to build the Java, generate the JNI headers, compile the C, and link the Shared Object.  Due to
+Gradle (>= 4.6) is used to build the Java, generate the JNI headers, compile the C, and link the Shared Object.  Due to
 the complexity of these moving pieces, they need to be run in a certain order:
 
  1. `>$ gradle -i -x test clean build` -- build the Java and compile the C.  Omit the tests as they're not ready yet.
- 1. `>$ gradle -i assembleSharedJar` -- Copy the Shared Object into the build folder and build the JAR file.
+ 1. `>$ gradle -i assembleSharedJar` -- Copy the Shared Object into the build folder and build the JAR file.  The Shared Object will be linked against the system's `libwcs.so`.
  1. `>$ gradle -i test` -- Now run the tests as the JAR file is complete

--- a/cadc-wcs/README.md
+++ b/cadc-wcs/README.md
@@ -1,10 +1,21 @@
+CADC WCS 2.0
+============
 
-The cadc-wcs library is the java interface to wcslib (http://www.atnf.csiro.au/people/mcalabre/WCS/). 
+The cadc-wcs library is the java interface to `wcslib` (http://www.atnf.csiro.au/people/mcalabre/WCS/). 
 
-This library can be built on it's own but testing and beyond requires wcslib. The JNI binding library is
-compiled and included inside the cadc-wcs jar file and deployed during class loading.
+This library can be built on its own but testing and beyond requires wcslib. The JNI binding library is
+compiled and included inside the `cadc-wcs` JAR file and deployed during class loading.
 
 Versions: 
 - cadc-wcs-1.x binaries on JCenter are linked against wcslib-4
-- cadc-wcs-2.x binaries on JCenter are linked against wcslib-5
+- cadc-wcs-2.x binaries on JCenter are linked against >= wcslib-5
 
+Building & Testing
+------------------
+
+Gradle is used to build the Java, generate the JNI headers, compile the C, and link the Shared Object.  Due to
+the complexity of these moving pieces, they need to be run in a certain order:
+
+ 1. `>$ gradle -i -x test clean build` -- build the Java and compile the C.  Omit the tests as they're not ready yet.
+ 1. `>$ gradle -i assembleSharedJar` -- Copy the Shared Object into the build folder and build the JAR file.
+ 1. `>$ gradle -i test` -- Now run the tests as the JAR file is complete

--- a/cadc-wcs/build.gradle
+++ b/cadc-wcs/build.gradle
@@ -1,57 +1,83 @@
+import org.gradle.internal.jvm.Jvm
+
 plugins {
-  id 'c'
-  id 'java'
-  id 'maven'
-  id 'maven-publish'
-  id 'com.jfrog.bintray' version '1.7.1'
+    id 'c'
+    id 'java'
+    id 'maven'
+    id 'application'
+    id 'maven-publish'
+    id 'com.jfrog.bintray' version '1.8.5'
 }
 
 repositories {
-  jcenter()
-  mavenLocal()
-
-  // Only here until cadcUtil is in jcenter.
-  maven {
-    url "http://dl.bintray.com/opencadc/software"
-  }
+    mavenLocal()
+    jcenter()
 }
 
-sourceCompatibility = 1.7
-
+sourceCompatibility = 1.8
 group = 'org.opencadc'
-
 version = '2.0'
 
 dependencies {
-  compile 'log4j:log4j:1.+'
-  compile 'org.opencadc:cadc-util:1.+'
+    compile 'log4j:log4j:1.2.17'
+    compile 'org.opencadc:cadc-util:[1.3.13,2.0.0)'
 
-  testCompile 'junit:junit:4.+'
+    testCompile 'junit:junit:[4.13,5.0]'
 }
 
 def tmpBuildDir = 'build/tmp'
-def jniLibDir = '/usr/lib/jvm/java/include'
+def baseHeadersDir = "${Jvm.current().javaHome}/include"
+
+test {
+    systemProperty "java.library.path", "/usr/local/lib:/usr/lib:/usr/lib64:" + System.getProperty("java.io.tmpdir")
+}
+
+def getSOFileLocation() {
+    def soFile = file('/usr/lib64/libwcs.so')
+    if (!soFile.exists()) {
+        soFile = file('/usr/lib/libwcs.so')
+    }
+
+    if (!soFile.exists()) {
+        soFile = file('/usr/local/lib/libwcs.so')
+    }
+
+    if (!soFile.exists()) {
+        soFile = file('/usr/lib/x86_64-linux-gnu/libwcs.so')
+    }
+
+    if (!soFile.exists()) {
+        throw new Error("No WCS SO file found.")
+    }
+
+//    copy {
+//        from soFile
+//        into dir
+//    }
+    return soFile.absolutePath
+}
+
+def copySOFile() {
+    def soFileLocation = getSOFileLocation()
+    copy {
+        from soFileLocation
+        into "./"
+    }
+}
 
 model {
-
     repositories {
         libs(PrebuiltLibraries) {
-            wcsx {
-                headers.srcDir '/usr/include/wcslib'
-                binaries.withType(SharedLibraryBinary) {
-                    // swugly: check for libwcs.so in some places it might be
-                    sharedLibraryFile = file('/usr/lib64/libwcs.so')
-                    if (!sharedLibraryFile.exists()) {
-                        sharedLibraryFile = file('/usr/lib/libwcs.so')
-                    }
-                    if (!sharedLibraryFile.exists()) {
-                        sharedLibraryFile = file('/usr/local/lib/libwcs.so')
-                    }
-                }
-            }    
+//            cadcwcs {
+//                binaries.withType(SharedLibraryBinary) {
+//                    // swugly: check for libwcs.so in some places it might be
+//                    copySOFile()
+//                    sharedLibraryFile = file("libwcs.so")
+//                }
+//            }
 
             jni {
-                headers.srcDirs = [jniLibDir, jniLibDir + '/linux', tmpBuildDir]
+                headers.srcDirs = [baseHeadersDir, baseHeadersDir + "/linux", tmpBuildDir]
             }
         }
     }
@@ -62,45 +88,45 @@ model {
             sources {
                 c {
                     lib library: 'jni', linkage: 'api'
-                    lib library: 'wcsx', linkage: 'shared'
+//                    lib library: 'cadcwcs', linkage: 'shared'
                 }
             }
 
+            // Linux compatible flags only.  This will likely never run on MacOS or Windows due to linkage issues.
             binaries.all {
                 cCompiler.args '-fexceptions',
-                '-ansi',
-                '-std=c99',
-                '-pedantic',
-                '-Wall',
-                '-Wno-parentheses',
-                '-Wno-long-long',
-                '-Wimplicit',
-                '-D_REENTRANT',
-                '-DCOMPILE_STYLE=ANSI_C_COMPILE',
-                '-DCOMPILER_gnu',
-                '-Dx86_linux',
-                '-D_POSIX_C_SOURCE=2'
+                        '-ansi',
+                        '-std=c99',
+                        '-pedantic',
+                        '-Wall',
+                        '-Dx86_linux',
+                        '-D_POSIX_C_SOURCE=2',
+                        '-D_FILE_OFFSET_BITS=64'
             }
         }
     }
-
 }
 
-task generateJNIHeader(type:Exec) {
-  def classpath = sourceSets.main.output.classesDir
-  def classname = 'ca.nrc.cadc.wcs.WCSLib'
-  commandLine 'javah', '-d', tmpBuildDir, '-classpath', classpath, classname
+task generateJniHeaders(type: JavaCompile) {
+    classpath = sourceSets.main.compileClasspath
+    destinationDir file("${tmpBuildDir}")
+    source = sourceSets.main.java
+    options.compilerArgs += [
+            '-h', file("${tmpBuildDir}"),
+            '-d', file("${tmpBuildDir}")
+    ]
+//    options.verbose = true
 }
 
-task copySharedLibrary(type:Copy) {
-    // ugh: different versions of gradle put the .so in different places
-    from 'build/libs/wcsLibJNI/shared/libwcsLibJNI.so'           // gradle 3
-    from 'build/binaries/wcsLibJNISharedLibrary/libwcsLibJNI.so' // gradle 2
-    into sourceSets.main.output.classesDir
+task copySharedLibrary(type: Copy) {
+    def soFileLocation = getSOFileLocation()
+    from "${buildDir}/libs/wcsLibJNI/shared/libwcsLibJNI.so"           // gradle >= 3
+    from soFileLocation
+    into file("${buildDir}/classes/java/main/")
 }
 
-task assembleSharedJar(type:Jar) {
-  from(sourceSets.main.output)
+task assembleSharedJar(type: Jar) {
+    from(sourceSets.main.output)
 }
 
 // change the default order of task execution so it does:
@@ -110,6 +136,6 @@ task assembleSharedJar(type:Jar) {
 // - jar construction
 //
 jar.enabled = false
-classes.dependsOn generateJNIHeader
+classes.dependsOn generateJniHeaders
 assembleSharedJar.dependsOn copySharedLibrary
 compileTestJava.dependsOn copySharedLibrary, assembleSharedJar

--- a/cadc-wcs/build.gradle
+++ b/cadc-wcs/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 sourceCompatibility = 1.8
 group = 'org.opencadc'
-version = '2.0'
+version = '3.0'
 
 dependencies {
     compile 'log4j:log4j:1.2.17'
@@ -50,31 +50,18 @@ def getSOFileLocation() {
         throw new Error("No WCS SO file found.")
     }
 
-//    copy {
-//        from soFile
-//        into dir
-//    }
-    return soFile.absolutePath
-}
-
-def copySOFile() {
-    def soFileLocation = getSOFileLocation()
-    copy {
-        from soFileLocation
-        into "./"
-    }
+    return soFile
 }
 
 model {
     repositories {
         libs(PrebuiltLibraries) {
-//            cadcwcs {
-//                binaries.withType(SharedLibraryBinary) {
-//                    // swugly: check for libwcs.so in some places it might be
-//                    copySOFile()
-//                    sharedLibraryFile = file("libwcs.so")
-//                }
-//            }
+           wcsx {
+               binaries.withType(SharedLibraryBinary) {
+                   // swugly: check for libwcs.so in some places it might be
+                   sharedLibraryFile = getSOFileLocation()
+               }
+           }
 
             jni {
                 headers.srcDirs = [baseHeadersDir, baseHeadersDir + "/linux", tmpBuildDir]
@@ -88,7 +75,7 @@ model {
             sources {
                 c {
                     lib library: 'jni', linkage: 'api'
-//                    lib library: 'cadcwcs', linkage: 'shared'
+                    lib library: 'wcsx', linkage: 'shared'
                 }
             }
 
@@ -119,9 +106,7 @@ task generateJniHeaders(type: JavaCompile) {
 }
 
 task copySharedLibrary(type: Copy) {
-    def soFileLocation = getSOFileLocation()
     from "${buildDir}/libs/wcsLibJNI/shared/libwcsLibJNI.so"           // gradle >= 3
-    from soFileLocation
     into file("${buildDir}/classes/java/main/")
 }
 


### PR DESCRIPTION
 - Compiled against WCSLIB >= 7.4
 - Now supports latest Gradle and remove obsolete "javah" command.