### PR TITLE
Native load macos

### DIFF
--- a/cadc-wcs/build.gradle
+++ b/cadc-wcs/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 sourceCompatibility = 1.8
 group = 'org.opencadc'
-version = '2.1.3'
+version = '2.1.4'
 
 description = 'OpenCADC WCS JNI library'
 def git_url = 'https://github.com/opencadc/wcs'

--- a/cadc-wcs/src/main/java/ca/nrc/cadc/wcs/NativeUtil.java
+++ b/cadc-wcs/src/main/java/ca/nrc/cadc/wcs/NativeUtil.java
@@ -137,14 +137,15 @@ public class NativeUtil
                 log.debug("extracted: " + url.toExternalForm() + " -> " + tmp.getAbsolutePath());
 
                 if (NativeUtil.extension.equals(NativeUtil.MACOS_EXTENSION)) {
-                    log.info("Loading WCS main library");
+                    log.debug("Loading WCS main library for macOS");
                     // Necessary to preload this on macOS.
                     try {
                         System.loadLibrary("wcs");
                     } catch (UnsatisfiedLinkError unsatisfiedLinkError) {
+                        // Error is quietly swallowed otherwise...
                         unsatisfiedLinkError.printStackTrace();
                     }
-                    log.info("Loading WCS main library: OK");
+                    log.debug("Loading WCS main library for macOS: OK");
                 }
 
                 System.load(tmp.getAbsolutePath());

--- a/cadc-wcs/src/main/java/ca/nrc/cadc/wcs/NativeUtil.java
+++ b/cadc-wcs/src/main/java/ca/nrc/cadc/wcs/NativeUtil.java
@@ -87,13 +87,14 @@ public class NativeUtil
 {
     private static final Logger log = Logger.getLogger(NativeUtil.class);
     private static String extension = ".so";
+    private static final String MACOS_EXTENSION = ".dylib";
 
     // for OSX, use .dylib as the library filename extension
     static {
         String osName = System.getProperty("os.name").toLowerCase();
         boolean isMacOs = osName.startsWith("mac os x");
         if (isMacOs) {
-            extension = ".dylib";
+            extension = NativeUtil.MACOS_EXTENSION;
         }
     }
 
@@ -134,6 +135,17 @@ public class NativeUtil
                 }
                 ostream.close();
                 log.debug("extracted: " + url.toExternalForm() + " -> " + tmp.getAbsolutePath());
+
+                if (NativeUtil.extension.equals(NativeUtil.MACOS_EXTENSION)) {
+                    log.info("Loading WCS main library");
+                    // Necessary to preload this on macOS.
+                    try {
+                        System.loadLibrary("wcs");
+                    } catch (UnsatisfiedLinkError unsatisfiedLinkError) {
+                        unsatisfiedLinkError.printStackTrace();
+                    }
+                    log.info("Loading WCS main library: OK");
+                }
 
                 System.load(tmp.getAbsolutePath());
                 log.debug("loaded: " + tmp.getAbsolutePath());


### PR DESCRIPTION
Correcting native macOS loading.  The `wcs` library needs to be pre-loaded, likely due to unpredictable linker locations.